### PR TITLE
Support http_proxy in download helper

### DIFF
--- a/libraries/codeplex.rb
+++ b/libraries/codeplex.rb
@@ -11,7 +11,8 @@ class CodePlex
   def self.download_url(project_name, download_id)
     download_url = nil
 
-    http = Net::HTTP.new("#{project_name}.codeplex.com")
+    proxy_uri = URI.parse(Chef::Config[:http_proxy] || "")
+    http = Net::HTTP.new("#{project_name}.codeplex.com", 80, proxy_uri.host, proxy_uri.port)
 
     # GET /downloads/get/:ID for cookie and token
     resp = http.get("/downloads/get/#{download_id}")


### PR DESCRIPTION
Please try to think of all the poor souls that sit behind a mandatory proxy when adding custom http calls in cookbooks...