### PR TITLE
Cache CodePlex download url

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ namespace :style do
     FoodCritic::Rake::LintTask.new(:chef) do |t|
       t.options = {
         fail_tags: ['any'],
-        progress: true
+        progress: true,
       }
     end
   rescue LoadError

--- a/libraries/codeplex.rb
+++ b/libraries/codeplex.rb
@@ -29,7 +29,7 @@ class CodePlex
       # POST /releases/captureDownload for a download url
       post_headers = {
         'Cookie' => cookie,
-        'Content-Type' => 'application/x-www-form-urlencoded'
+        'Content-Type' => 'application/x-www-form-urlencoded',
       }
 
       post_data = "fileId=#{download_id}&clickOncePath=&allowRedirectToAds=false&__RequestVerificationToken=#{token}"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,11 +18,17 @@
 # limitations under the License.
 #
 
-download_url  = CodePlex.download_url('wix', node['wix']['download_id'])
+download_url = CodePlex.download_url('wix', node['wix']['download_id'])
+download_url_path = File.join(Chef::Config[:file_cache_path], "wix-#{node['wix']['download_id']}.url")
 download_path = File.join(Chef::Config[:file_cache_path], "wix-#{node['wix']['download_id']}.zip")
 
+file download_url_path do
+  content download_url
+  not_if { download_url.nil? }
+end
+
 remote_file download_path do
-  source download_url
+  source(lazy { File.read(download_url_path) })
   checksum node['wix']['checksum']
   notifies :unzip, "windows_zipfile[#{node['wix']['home']}]", :immediately
 end


### PR DESCRIPTION
Sometimes the CodePlex code returns `nil`, which breaks everything.

Fixes issue #9
